### PR TITLE
🕳 Ignore a SQL context use line

### DIFF
--- a/fixtures/index.js
+++ b/fixtures/index.js
@@ -99,4 +99,23 @@ select sleep(3);`,
             query: `select sleep(1.1)`,
         },
     ],
+    [
+        `# User@Host: submitter[submitter] @ [172.16.235.69] Id: 3434185
+# Query_time: 0.003231 Lock_time: 0.000053 Rows_sent: 218 Rows_examined: 218
+use submiterr_production;
+SET timestamp=1555754404;
+SELECT \`jobs\`.* FROM \`jobs\`;`,
+        {
+            user: 'submitter',
+            host: '',
+            ip: '172.16.235.69',
+            id: '3434185',
+            duration: 0.003231,
+            lock_wait: 0.000053,
+            rows_sent: 218,
+            rows_examined: 218,
+            timestamp: 1555754404000,
+            query: `SELECT \`jobs\`.* FROM \`jobs\``,
+        },
+    ],
 ];

--- a/lib/pattern/index.js
+++ b/lib/pattern/index.js
@@ -5,11 +5,12 @@ const matchers = [
     'Lock_time: ([\\d\\.]*)',
     'Rows_sent: (\\d*)',
     'Rows_examined: (\\d*)',
+    '(?:use [\\w\\d]*; )?',
     'SET timestamp=(\\d*);',
     '(.*);',
 ];
 
 module.exports = {
-    pattern: new RegExp(matchers.join(' ')),
+    pattern: new RegExp(matchers.join('\\s*')),
     matchers,
 };

--- a/lib/pattern/index.js
+++ b/lib/pattern/index.js
@@ -1,12 +1,19 @@
+const USERNAME = '(\\w*)\\[\\w*\\]';
+const HOSTNAME = '([\\w\\d\\.-]*)';
+const IP = '\\[([\\d\\.]*)\\]';
+const DIGITS_SEQUENCE = '(\\d*)';
+const DECIMAL_NUMBER = '([\\d\\.]*)';
+const TABLE_NAME = '[\\w\\d]*';
+
 const matchers = [
-    'User@Host: (\\w*)\\[\\w*\\] @ ([\\w\\d\\.-]*)\\s?\\[([\\d\\.]*)\\]',
-    'Id: (\\d*) #',
-    'Query_time: ([\\d\\.]*)',
-    'Lock_time: ([\\d\\.]*)',
-    'Rows_sent: (\\d*)',
-    'Rows_examined: (\\d*)',
-    '(?:use [\\w\\d]*; )?',
-    'SET timestamp=(\\d*);',
+    `User@Host: ${USERNAME} @ ${HOSTNAME}\\s?${IP}`,
+    `Id: ${DIGITS_SEQUENCE} #`,
+    `Query_time: ${DECIMAL_NUMBER}`,
+    `Lock_time: ${DECIMAL_NUMBER}`,
+    `Rows_sent: ${DIGITS_SEQUENCE}`,
+    `Rows_examined: ${DIGITS_SEQUENCE}`,
+    `(?:use ${TABLE_NAME}; )?`,
+    `SET timestamp=${DIGITS_SEQUENCE};`,
     '(.*);',
 ];
 

--- a/lib/pattern/spec.js
+++ b/lib/pattern/spec.js
@@ -1,7 +1,7 @@
 const {pattern, matchers} = require('.');
 
 describe('RDS/pattern', () => {
-    test('Should create a patterns comprised of all matchers', () => {
+    test('Should create a patterns comprised of all matchers, separated by 0 or more spaces', () => {
         expect(pattern.source).toEqual(matchers.join('\\s*'));
     });
 

--- a/lib/pattern/spec.js
+++ b/lib/pattern/spec.js
@@ -2,7 +2,7 @@ const {pattern, matchers} = require('.');
 
 describe('RDS/pattern', () => {
     test('Should create a patterns comprised of all matchers', () => {
-        expect(pattern.source).toEqual(matchers.join(' '));
+        expect(pattern.source).toEqual(matchers.join('\\s*'));
     });
 
     const [
@@ -12,6 +12,7 @@ describe('RDS/pattern', () => {
         lock_wait,
         rows_sent,
         rows_examined,
+        use,
         timestamp,
         query,
     ] = matchers.map((part) => new RegExp(part));
@@ -64,6 +65,12 @@ describe('RDS/pattern', () => {
         test('Should extract rows_examined', () => {
             const [, match] = rows_examined.exec('Rows_examined: 12');
             expect(match).toEqual('12');
+        });
+    });
+    describe('use', () => {
+        test('Should ignore SQL context content', () => {
+            const [, match] = use.exec('use submiterr_production;');
+            expect(match).toBeUndefined();
         });
     });
     describe('timestamp', () => {


### PR DESCRIPTION
1. Add line with optional capturing group where `[\\w\\d]*` stands for table name.
2. Replace regex parts separator with optional (0 or more) spaces
3. Give regex parts readable variable names